### PR TITLE
Description & resource in pom.xml for resources from parent resolving

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -15,22 +15,6 @@
     </properties>
 
     <build>
-        <resources>
-            <resource>
-                <directory>${project.basedir}/src/main/resources</directory>
-                <includes>
-                    <include>META-INF/jqassistant-plugin.xml</include>
-                </includes>
-                <filtering>true</filtering>
-            </resource>
-            <resource>
-                <directory>${project.basedir}/src/main/resources</directory>
-                <excludes>
-                    <exclude>META-INF/jqassistant-plugin.xml</exclude>
-                </excludes>
-                <filtering>false</filtering>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/java/src/main/resources/META-INF/jqassistant-plugin.xml
+++ b/java/src/main/resources/META-INF/jqassistant-plugin.xml
@@ -3,7 +3,7 @@
                     xsi:schemaLocation="http://schema.jqassistant.org/plugin/v2.4 https://schema.jqassistant.org/plugin/jqassistant-plugin-v2.4.xsd"
                     name="jQAssistant Dart Plugin" id="jqassistant.plugin.dart"
                     version="${project.version}">
-    <description>Provides a scanner for Dart.</description>
+    <description>${project.description}</description>
     <model>
         <class>org.jqassistant.plugin.dart.api.model.core.ClassDescriptor</class>
         <class>org.jqassistant.plugin.dart.api.model.core.FunctionDescriptor</class>


### PR DESCRIPTION
Changed description in jqassistant-plugin.xml to interpolation string and deleted redundant resource info in pom.xml